### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/yatarousan0227/agent-contracts/security/code-scanning/1](https://github.com/yatarousan0227/agent-contracts/security/code-scanning/1)

In general, the fix is to explicitly specify `permissions` for the GITHUB_TOKEN either at the workflow root (applies to all jobs) or at the job level (for finer control), granting only the minimal scopes required. For this workflow, the job only reads repository contents (via `actions/checkout`) and runs local commands, so `contents: read` is sufficient.

The best minimal fix without changing behavior is to add a `permissions` block at the workflow root, just after the `on:` section (or before `jobs:`), setting `contents: read`. This applies to all jobs that don’t override `permissions`, including `test`. No additional imports or external tools are needed since this is pure GitHub Actions YAML configuration.

Concretely, in `.github/workflows/ci.yml`, between the `on:` block (lines 3–7) and the `jobs:` block (line 9), insert:

```yaml
permissions:
  contents: read
```

This ensures the `GITHUB_TOKEN` has read-only access to repository contents, satisfying CodeQL’s recommendation and maintaining existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
