### PR TITLE
Add support assistant example package (config, nodes, graph, runtime, CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,13 @@ See `docs/cli.md` for details.
 - `examples/05_backend_runtime.py`: backend-oriented runtime with strict validation
 - `examples/03_simple_chatbot.py`: minimal rule-based routing
 - `examples/04_multi_step_workflow.py`: sequential workflow pattern
+- `examples/support_assistant`: modular support assistant package (config, nodes, runtime, CLI)
+
+Run the support assistant CLI:
+
+```bash
+PYTHONPATH=examples/support_assistant:src python -m support_assistant.cli "パスワードを忘れました"
+```
 
 ---
 

--- a/examples/support_assistant/support_assistant/__init__.py
+++ b/examples/support_assistant/support_assistant/__init__.py
@@ -1,0 +1,5 @@
+"""Support assistant example package."""
+
+from support_assistant.runtime import build_runtime, build_request_context
+
+__all__ = ["build_runtime", "build_request_context"]

--- a/examples/support_assistant/support_assistant/cli.py
+++ b/examples/support_assistant/support_assistant/cli.py
@@ -1,0 +1,45 @@
+"""CLI entry point for the support assistant example."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+from typing import Callable
+
+from support_assistant.runtime import build_request_context, build_runtime
+
+
+async def run_once(
+    message: str,
+    session_id: str,
+    use_llm: bool,
+    llm_provider: Callable[[], object] | None,
+) -> None:
+    runtime = build_runtime(use_llm=use_llm, llm_provider=llm_provider)
+    request = build_request_context(message, session_id=session_id, use_llm=use_llm)
+    result = await runtime.execute(request)
+    print(result.to_response_dict())
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Support assistant CLI")
+    parser.add_argument("message", nargs="?", help="User message")
+    parser.add_argument("--session-id", default="demo", help="Session identifier")
+    parser.add_argument("--llm", action="store_true", help="Enable LLM-based routing")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    message = args.message or input("Message: ").strip()
+    if not message:
+        raise SystemExit("Message is required")
+    if args.llm:
+        raise SystemExit(
+            "LLM routing requires an injected llm_provider. "
+            "Use build_runtime(use_llm=True, llm_provider=...) in code."
+        )
+    asyncio.run(run_once(message, args.session_id, args.llm, llm_provider=None))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/support_assistant/support_assistant/config/__init__.py
+++ b/examples/support_assistant/support_assistant/config/__init__.py
@@ -1,0 +1,5 @@
+"""Support assistant configuration."""
+
+from support_assistant.config.loader import DEFAULT_CONFIG_PATH, load_support_config
+
+__all__ = ["DEFAULT_CONFIG_PATH", "load_support_config"]

--- a/examples/support_assistant/support_assistant/config/defaults.yaml
+++ b/examples/support_assistant/support_assistant/config/defaults.yaml
@@ -1,0 +1,12 @@
+supervisor:
+  max_iterations: 6
+response_types:
+  terminal_states:
+    - faq_answered
+    - ticket_created
+    - handoff
+    - fallback
+io:
+  strict: false
+  warn: true
+  drop_undeclared_writes: true

--- a/examples/support_assistant/support_assistant/config/loader.py
+++ b/examples/support_assistant/support_assistant/config/loader.py
@@ -1,0 +1,22 @@
+"""Support assistant configuration loader."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_contracts.config import FrameworkConfig, load_config, set_config
+
+DEFAULT_CONFIG_PATH = Path(__file__).with_name("defaults.yaml")
+
+
+def load_support_config(path: Path | str = DEFAULT_CONFIG_PATH) -> FrameworkConfig:
+    """Load and apply support assistant configuration.
+
+    Args:
+        path: Path to YAML config file.
+
+    Returns:
+        Parsed FrameworkConfig instance.
+    """
+    config = load_config(path)
+    set_config(config)
+    return config

--- a/examples/support_assistant/support_assistant/data/__init__.py
+++ b/examples/support_assistant/support_assistant/data/__init__.py
@@ -1,0 +1,11 @@
+"""Support assistant data entries."""
+
+from support_assistant.data.faq import FAQ_ENTRIES, find_faq_topic
+from support_assistant.data.intents import INTENT_KEYWORDS, INTENT_PRIORITY
+
+__all__ = [
+    "FAQ_ENTRIES",
+    "find_faq_topic",
+    "INTENT_KEYWORDS",
+    "INTENT_PRIORITY",
+]

--- a/examples/support_assistant/support_assistant/data/faq.py
+++ b/examples/support_assistant/support_assistant/data/faq.py
@@ -1,0 +1,29 @@
+"""Hard-coded FAQ entries for the support assistant."""
+
+FAQ_ENTRIES: dict[str, dict[str, object]] = {
+    "password_reset": {
+        "question": "パスワードをリセットするには？",
+        "answer": "ログイン画面の『パスワードを忘れた場合』から再設定できます。",
+        "keywords": ["パスワード", "リセット", "忘れた", "password", "reset"],
+    },
+    "billing": {
+        "question": "請求書や支払い方法を確認したい",
+        "answer": "アカウント設定の『請求』から請求書の確認と支払い方法の変更ができます。",
+        "keywords": ["請求", "支払い", "billing", "invoice"],
+    },
+    "troubleshooting": {
+        "question": "アプリが起動しません",
+        "answer": "最新版への更新後、端末を再起動してから再度お試しください。",
+        "keywords": ["起動", "クラッシュ", "動かない", "crash", "launch"],
+    },
+}
+
+
+def find_faq_topic(message: str) -> str | None:
+    """Return matching FAQ topic key for a message."""
+    lowered = message.lower()
+    for topic, entry in FAQ_ENTRIES.items():
+        for keyword in entry.get("keywords", []):
+            if keyword.lower() in lowered:
+                return topic
+    return None

--- a/examples/support_assistant/support_assistant/data/intents.py
+++ b/examples/support_assistant/support_assistant/data/intents.py
@@ -1,0 +1,9 @@
+"""Hard-coded intent keyword mappings."""
+
+INTENT_KEYWORDS: dict[str, list[str]] = {
+    "handoff": ["human", "agent", "担当者", "オペレーター", "人に", "問い合わせ"],
+    "create_ticket": ["チケット", "サポート", "issue", "problem", "助けて"],
+    "faq": ["パスワード", "請求", "起動", "reset", "billing", "crash"],
+}
+
+INTENT_PRIORITY = ["handoff", "create_ticket", "faq"]

--- a/examples/support_assistant/support_assistant/graph.py
+++ b/examples/support_assistant/support_assistant/graph.py
@@ -1,0 +1,62 @@
+"""Graph construction for the support assistant."""
+from __future__ import annotations
+
+from typing import Callable
+
+from langgraph.graph import StateGraph, END
+
+from agent_contracts import BaseAgentState, ContractValidator, NodeRegistry
+from agent_contracts.graph_builder import GraphBuilder
+
+from support_assistant.nodes import CreateTicketNode, FallbackNode, FaqNode, HandoffNode
+
+
+def build_support_graph(
+    llm_provider: Callable[[], object] | None = None,
+) -> StateGraph:
+    """Build the support assistant graph with GraphBuilder."""
+    registry = NodeRegistry()
+    registry.add_valid_slice("ticket")
+    registry.register(FaqNode)
+    registry.register(CreateTicketNode)
+    registry.register(HandoffNode)
+    registry.register(FallbackNode)
+
+    validator = ContractValidator(registry, strict=True)
+    result = validator.validate()
+    if result.has_errors:
+        raise SystemExit(str(result))
+
+    builder = GraphBuilder(
+        registry=registry,
+        state_class=BaseAgentState,
+        llm_provider=llm_provider,
+    )
+    builder.add_supervisor("support")
+
+    graph = StateGraph(BaseAgentState)
+
+    for sup_name in builder.supervisor_names:
+        graph.add_node(f"{sup_name}_supervisor", builder.create_supervisor_wrapper(sup_name))
+
+    for node_name in builder.node_classes.keys():
+        graph.add_node(node_name, builder.create_node_wrapper(node_name))
+
+    for sup_name in builder.supervisor_names:
+        route_fn = builder.create_routing_function(sup_name)
+        graph.add_conditional_edges(
+            f"{sup_name}_supervisor",
+            route_fn,
+            builder.build_routing_map(sup_name),
+        )
+
+    for node_name, node_cls in builder.node_classes.items():
+        contract = node_cls.CONTRACT
+        sup_name = contract.supervisor
+        if contract.is_terminal:
+            graph.add_edge(node_name, END)
+        else:
+            graph.add_edge(node_name, f"{sup_name}_supervisor")
+
+    graph.set_entry_point("support_supervisor")
+    return graph

--- a/examples/support_assistant/support_assistant/nodes/__init__.py
+++ b/examples/support_assistant/support_assistant/nodes/__init__.py
@@ -1,0 +1,8 @@
+"""Support assistant nodes."""
+
+from support_assistant.nodes.faq import FaqNode
+from support_assistant.nodes.fallback import FallbackNode
+from support_assistant.nodes.handoff import HandoffNode
+from support_assistant.nodes.ticket import CreateTicketNode
+
+__all__ = ["FaqNode", "FallbackNode", "HandoffNode", "CreateTicketNode"]

--- a/examples/support_assistant/support_assistant/nodes/fallback.py
+++ b/examples/support_assistant/support_assistant/nodes/fallback.py
@@ -1,0 +1,32 @@
+"""Fallback node."""
+from __future__ import annotations
+
+from agent_contracts import ModularNode, NodeContract, NodeInputs, NodeOutputs, TriggerCondition
+
+
+class FallbackNode(ModularNode):
+    """Handle unsupported requests."""
+
+    CONTRACT = NodeContract(
+        name="fallback",
+        description="Fallback response for unsupported intents.",
+        reads=["request"],
+        writes=["response"],
+        supervisor="support",
+        is_terminal=True,
+        trigger_conditions=[
+            TriggerCondition(
+                priority=1,
+                llm_hint="Fallback response when intent is unclear.",
+            )
+        ],
+    )
+
+    async def execute(self, inputs: NodeInputs, config=None) -> NodeOutputs:
+        return NodeOutputs(
+            response={
+                "response_type": "fallback",
+                "response_message": "内容を確認できませんでした。詳しく教えてください。",
+                "response_data": {"next": "clarify"},
+            }
+        )

--- a/examples/support_assistant/support_assistant/nodes/faq.py
+++ b/examples/support_assistant/support_assistant/nodes/faq.py
@@ -1,0 +1,43 @@
+"""FAQ response node."""
+from __future__ import annotations
+
+from agent_contracts import ModularNode, NodeContract, NodeInputs, NodeOutputs, TriggerCondition
+
+from support_assistant.data import FAQ_ENTRIES, find_faq_topic
+
+
+class FaqNode(ModularNode):
+    """Answer common FAQ questions."""
+
+    CONTRACT = NodeContract(
+        name="faq_answer",
+        description="Answer frequently asked questions.",
+        reads=["request"],
+        writes=["response"],
+        supervisor="support",
+        is_terminal=True,
+        trigger_conditions=[
+            TriggerCondition(
+                priority=40,
+                when={"request.action": "faq"},
+                llm_hint="Answer FAQs about password reset, billing, or troubleshooting.",
+            )
+        ],
+    )
+
+    async def execute(self, inputs: NodeInputs, config=None) -> NodeOutputs:
+        request = inputs.get_slice("request")
+        params = request.get("params") or {}
+        message = (request.get("message") or "").strip()
+        topic = params.get("topic") or find_faq_topic(message)
+        entry = FAQ_ENTRIES.get(topic or "", {})
+        answer = entry.get("answer") if entry else None
+        if not answer:
+            answer = "該当するFAQが見つかりませんでした。"
+        return NodeOutputs(
+            response={
+                "response_type": "faq_answered",
+                "response_message": answer,
+                "response_data": {"topic": topic, "source": "faq"},
+            }
+        )

--- a/examples/support_assistant/support_assistant/nodes/handoff.py
+++ b/examples/support_assistant/support_assistant/nodes/handoff.py
@@ -1,0 +1,33 @@
+"""Human handoff node."""
+from __future__ import annotations
+
+from agent_contracts import ModularNode, NodeContract, NodeInputs, NodeOutputs, TriggerCondition
+
+
+class HandoffNode(ModularNode):
+    """Escalate to a human operator."""
+
+    CONTRACT = NodeContract(
+        name="handoff",
+        description="Route to a human agent.",
+        reads=["request"],
+        writes=["response"],
+        supervisor="support",
+        is_terminal=True,
+        trigger_conditions=[
+            TriggerCondition(
+                priority=60,
+                when={"request.action": "handoff"},
+                llm_hint="Escalate to a human agent.",
+            )
+        ],
+    )
+
+    async def execute(self, inputs: NodeInputs, config=None) -> NodeOutputs:
+        return NodeOutputs(
+            response={
+                "response_type": "handoff",
+                "response_message": "担当者におつなぎします。",
+                "response_data": {"channel": "human_support"},
+            }
+        )

--- a/examples/support_assistant/support_assistant/nodes/ticket.py
+++ b/examples/support_assistant/support_assistant/nodes/ticket.py
@@ -1,0 +1,40 @@
+"""Ticket creation node."""
+from __future__ import annotations
+
+from uuid import uuid4
+
+from agent_contracts import ModularNode, NodeContract, NodeInputs, NodeOutputs, TriggerCondition
+
+
+class CreateTicketNode(ModularNode):
+    """Create a support ticket."""
+
+    CONTRACT = NodeContract(
+        name="create_ticket",
+        description="Create a support ticket for complex issues.",
+        reads=["request"],
+        writes=["ticket", "response"],
+        supervisor="support",
+        is_terminal=True,
+        trigger_conditions=[
+            TriggerCondition(
+                priority=50,
+                when={"request.action": "create_ticket"},
+                llm_hint="Create a support ticket for the user.",
+            )
+        ],
+    )
+
+    async def execute(self, inputs: NodeInputs, config=None) -> NodeOutputs:
+        request = inputs.get_slice("request")
+        params = request.get("params") or {}
+        title = params.get("title") or request.get("message") or "Support request"
+        ticket_id = f"TCK-{uuid4().hex[:6].upper()}"
+        return NodeOutputs(
+            ticket={"id": ticket_id, "title": title, "status": "open"},
+            response={
+                "response_type": "ticket_created",
+                "response_message": "サポートチケットを作成しました。",
+                "response_data": {"ticket_id": ticket_id, "title": title},
+            },
+        )

--- a/examples/support_assistant/support_assistant/runtime.py
+++ b/examples/support_assistant/support_assistant/runtime.py
@@ -1,0 +1,54 @@
+"""Runtime helpers for the support assistant."""
+from __future__ import annotations
+
+from typing import Callable
+
+from agent_contracts.runtime import AgentRuntime, RequestContext
+
+from support_assistant.config import load_support_config
+from support_assistant.data import INTENT_KEYWORDS, INTENT_PRIORITY, find_faq_topic
+from support_assistant.graph import build_support_graph
+
+
+def detect_intent(message: str) -> tuple[str, dict]:
+    """Detect intent from message using keyword matching."""
+    lowered = message.lower()
+    for intent in INTENT_PRIORITY:
+        for keyword in INTENT_KEYWORDS.get(intent, []):
+            if keyword.lower() in lowered:
+                if intent == "faq":
+                    topic = find_faq_topic(message)
+                    return "faq", {"topic": topic} if topic else {}
+                return intent, {}
+    return "fallback", {}
+
+
+def build_request_context(
+    message: str,
+    session_id: str = "demo",
+    use_llm: bool = False,
+) -> RequestContext:
+    """Create RequestContext with optional intent detection."""
+    params: dict | None = None
+    action: str | None = None
+    if not use_llm:
+        action, params = detect_intent(message)
+    return RequestContext(
+        session_id=session_id,
+        action=action,
+        params=params,
+        message=message,
+    )
+
+
+def build_runtime(
+    use_llm: bool = False,
+    llm_provider: Callable[[], object] | None = None,
+) -> AgentRuntime:
+    """Build AgentRuntime with optional LLM support."""
+    if use_llm and llm_provider is None:
+        raise ValueError("llm_provider is required when use_llm is True.")
+    load_support_config()
+    graph = build_support_graph(llm_provider=llm_provider if use_llm else None)
+    compiled = graph.compile()
+    return AgentRuntime(compiled)


### PR DESCRIPTION
### Motivation

- Provide a self-contained example showing how to build a modular support assistant using the framework's registry/GraphBuilder pattern and demonstrate LLM vs rule-based routing.
- Show how to structure an example package with separated `config`, `nodes`, `data`, `graph`, `runtime`, and a simple `cli` entrypoint for developers to run and iterate on.

### Description

- Added a new example package at `examples/support_assistant/support_assistant` including `config/defaults.yaml` and `config/loader.py` to load and apply example framework settings via `load_support_config`.
- Introduced hard-coded example data in `data/` with `faq.py` and `intents.py` and an aggregation `data/__init__.py` used by nodes for simple keyword-based intent and FAQ detection.
- Split nodes into separate files under `nodes/` (`faq.py`, `ticket.py`, `handoff.py`, `fallback.py`) each exposing a `NodeContract` and `execute` implementation, and registered them via a `graph.py` that builds the StateGraph with `GraphBuilder` and `ContractValidator(strict=True)`.
- Added `runtime.py` helpers that provide `build_runtime` (with an explicit guard requiring `llm_provider` when `use_llm=True`) and `build_request_context` (keyword intent detection when `use_llm=False`), plus a simple `cli.py` that runs the example but prevents enabling `--llm` from the CLI without an injected provider; updated `README.md` with run instructions.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f5c5abfd48333831dd3c98bf5972c)