### PR TITLE
Translate public API reference to English

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -1,0 +1,39 @@
+# Public API List
+
+This list fixes the public classes/functions that appear in the README and Getting Started guide.
+
+## Nodes and Contracts
+- `ModularNode`
+- `InteractiveNode`
+- `NodeContract`
+- `TriggerCondition`
+- `NodeInputs`
+- `NodeOutputs`
+- `StateAccessor`
+- `Internal`
+- `reset_response`
+
+## Registry and Graph
+- `NodeRegistry`
+- `GraphBuilder`
+- `get_node_registry`
+- `build_graph_from_registry`
+- `BaseAgentState`
+
+## Supervisor and Context
+- `GenericSupervisor`
+- `ContextBuilder` (protocol)
+
+## Runtime
+- `AgentRuntime`
+- `StreamingRuntime`
+- `RequestContext`
+- `ExecutionResult`
+- `RuntimeHooks`
+- `SessionStore`
+- `InMemorySessionStore`
+
+## Validation, Visualization, and Config
+- `ContractValidator`
+- `ContractVisualizer`
+- `load_config`


### PR DESCRIPTION
### Motivation
- Translate the `docs/api_reference.md` headings and intro from Japanese to English to improve clarity and consistency with the repository documentation.

### Description
- Replace the top-level heading and section labels in `docs/api_reference.md` with English equivalents while keeping the enumerated public API items unchanged.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69798ce9e3508333a7a73bf0f8033cef)