### PR TITLE
Add API reference links after Getting Started

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -15,6 +15,10 @@
 
 🧩 **公式Skills（エージェント指示ファイル）**: `docs/skills/official/index.md`
 
+**ドキュメント**
+- **Getting Started（入門ガイド）**: [docs/getting_started.ja.md](docs/getting_started.ja.md)
+- **API Reference**: [https://yatarousan0227.github.io/agent-contracts/](https://yatarousan0227.github.io/agent-contracts/)
+
 **LangGraphエージェントを構築するための、モジュール式・契約駆動型ノードアーキテクチャ。**
 
 ## ▶️ 対話デモを試す

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ English | [日本語](README.ja.md)
 
 🧩 **Official Skills (agent instructions)**: `docs/skills/official/index.md`
 
+**Documentation**
+- **Getting Started**: [docs/getting_started.md](docs/getting_started.md)
+- **API Reference**: [https://yatarousan0227.github.io/agent-contracts/](https://yatarousan0227.github.io/agent-contracts/)
+
 **A modular, contract-driven node architecture for building scalable LangGraph agents.**
 
 ## ▶️ Try the Interactive Demo

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -1,0 +1,18 @@
+# Agent Contracts ドキュメント
+
+**Agent Contracts** は、AIエージェント構築のための型安全でモジュール式、かつ観測性を重視したフレームワークです。
+
+## コアドキュメント
+
+- **[コアコンセプト](core_concepts.ja.md)**: ノード、スーパーバイザー、ランタイムなどの基本概念。
+- **[ベストプラクティス](best_practices.ja.md)**: 効果的なエージェント設計と状態管理の方法。
+- **[入門ガイド](getting_started.ja.md)**: 最初のエージェントを構築するためのクイックスタート。
+- **[API Reference](#api-reference)**: 公開APIと使い方の概要。
+- **[CLI](cli.ja.md)**: コントラクトの検証・可視化・差分。
+- **[Skills](skills/index.ja.md)**: 公式Skills（利用者向け）とテンプレ（コントリビューター向け）。
+- **[トラブルシューティング](troubleshooting.ja.md)**: よくある問題とその解決策。
+- **[アーキテクチャサンプル](ARCHITECTURE_SAMPLE.md)**: Mermaidによるアーキテクチャ図のサンプル。
+
+## API Reference
+
+詳細なAPIの使い方は、ソースコードとdocstringを参照してください。

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ Welcome to the documentation for **Agent Contracts**, a type-safe, modular, and 
 - **[Core Concepts](core_concepts.md)**: Understand the fundamental building blocks like Nodes, Supervisors, and the Runtime.
 - **[Best Practices](best_practices.md)**: Learn how to design effective agents and manage state.
 - **[Getting Started](getting_started.md)**: Quick start guide to build your first agent.
+- **[API Reference](#api-reference)**: Public APIs and usage details.
 - **[CLI](cli.md)**: Validate, visualize, and diff contracts.
 - **[Skills](skills/index.md)**: Official skills (users) and templates (contributors).
 - **[Troubleshooting](troubleshooting.md)**: Common issues and how to resolve them.
@@ -17,6 +18,7 @@ Welcome to the documentation for **Agent Contracts**, a type-safe, modular, and 
 - **[コアコンセプト](core_concepts.ja.md)**: ノード、スーパーバイザー、ランタイムなどの基本概念。
 - **[ベストプラクティス](best_practices.ja.md)**: 効果的なエージェント設計と状態管理の方法。
 - **[入門ガイド](getting_started.ja.md)**: 最初のエージェントを構築するためのクイックスタート。
+- **[API Reference](#api-reference)**: 公開APIと使い方の概要。
 - **[CLI](cli.ja.md)**: コントラクトの検証・可視化・差分。
 - **[Skills](skills/index.ja.md)**: 公式Skills（利用者向け）とテンプレ（コントリビューター向け）。
 - **[トラブルシューティング](troubleshooting.ja.md)**: よくある問題とその解決策。


### PR DESCRIPTION
### Motivation
- Improve documentation navigation by making the `API Reference` link visible immediately after `Getting Started` in both English and Japanese top-level docs.

### Description
- Add a `Documentation` block to `README.md` with links to `docs/getting_started.md` and the `API Reference` site.
- Add a matching `ドキュメント` block to `README.ja.md` linking `docs/getting_started.ja.md` and the `API Reference` site.
- Insert an `API Reference` entry after `Getting Started` in `docs/index.md`.
- Add a new `docs/index.ja.md` file containing a Japanese docs index that includes an `API Reference` section.

### Testing
- No automated tests were run because this is a docs-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69798f8854c88333bff7abc00e7f53a9)